### PR TITLE
Feature: Agregar y eliminar programas educativos

### DIFF
--- a/src/main/java/mx/edu/uteq/idgs13/microservicio_division/controller/DivisionController.java
+++ b/src/main/java/mx/edu/uteq/idgs13/microservicio_division/controller/DivisionController.java
@@ -34,29 +34,6 @@ public class DivisionController {
         return divisionRepository.findAll(); // Reemplaza con la lista real de divisiones
     }
     
-        @org.springframework.web.bind.annotation.PostMapping("/{divisionId}/programa-educativo")
-        public org.springframework.http.ResponseEntity<?> agregarProgramaEducativo(
-                @org.springframework.web.bind.annotation.PathVariable Long divisionId,
-                @org.springframework.web.bind.annotation.RequestBody mx.edu.uteq.idgs13.microservicio_division.entity.ProgramaEducativo programa) {
-            try {
-                Division result = divisionService.agregarProgramaEducativo(divisionId, programa);
-                return org.springframework.http.ResponseEntity.ok(result);
-            } catch (IllegalArgumentException e) {
-                return org.springframework.http.ResponseEntity.badRequest().body(e.getMessage());
-            }
-        }
-
-        @org.springframework.web.bind.annotation.DeleteMapping("/{divisionId}/programa-educativo/{programaId}")
-        public org.springframework.http.ResponseEntity<?> borrarProgramaEducativo(
-                @org.springframework.web.bind.annotation.PathVariable Long divisionId,
-                @org.springframework.web.bind.annotation.PathVariable Long programaId) {
-            try {
-                Division result = divisionService.borrarProgramaEducativo(divisionId, programaId);
-                return org.springframework.http.ResponseEntity.ok(result);
-            } catch (IllegalArgumentException e) {
-                return org.springframework.http.ResponseEntity.badRequest().body(e.getMessage());
-            }
-        }
 
 
 }

--- a/src/main/java/mx/edu/uteq/idgs13/microservicio_division/controller/DivisionController.java
+++ b/src/main/java/mx/edu/uteq/idgs13/microservicio_division/controller/DivisionController.java
@@ -33,6 +33,30 @@ public class DivisionController {
         // Lógica para obtener todas las divisiones
         return divisionRepository.findAll(); // Reemplaza con la lista real de divisiones
     }
+    
+        @org.springframework.web.bind.annotation.PostMapping("/{divisionId}/programa-educativo")
+        public org.springframework.http.ResponseEntity<?> agregarProgramaEducativo(
+                @org.springframework.web.bind.annotation.PathVariable Long divisionId,
+                @org.springframework.web.bind.annotation.RequestBody mx.edu.uteq.idgs13.microservicio_division.entity.ProgramaEducativo programa) {
+            try {
+                Division result = divisionService.agregarProgramaEducativo(divisionId, programa);
+                return org.springframework.http.ResponseEntity.ok(result);
+            } catch (IllegalArgumentException e) {
+                return org.springframework.http.ResponseEntity.badRequest().body(e.getMessage());
+            }
+        }
+
+        @org.springframework.web.bind.annotation.DeleteMapping("/{divisionId}/programa-educativo/{programaId}")
+        public org.springframework.http.ResponseEntity<?> borrarProgramaEducativo(
+                @org.springframework.web.bind.annotation.PathVariable Long divisionId,
+                @org.springframework.web.bind.annotation.PathVariable Long programaId) {
+            try {
+                Division result = divisionService.borrarProgramaEducativo(divisionId, programaId);
+                return org.springframework.http.ResponseEntity.ok(result);
+            } catch (IllegalArgumentException e) {
+                return org.springframework.http.ResponseEntity.badRequest().body(e.getMessage());
+            }
+        }
 
 
 }

--- a/src/main/java/mx/edu/uteq/idgs13/microservicio_division/controller/ProgramaEducativoController.java
+++ b/src/main/java/mx/edu/uteq/idgs13/microservicio_division/controller/ProgramaEducativoController.java
@@ -1,0 +1,61 @@
+package mx.edu.uteq.idgs13.microservicio_division.controller;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import mx.edu.uteq.idgs13.microservicio_division.entity.ProgramaEducativo;
+import mx.edu.uteq.idgs13.microservicio_division.service.ProgramaEducativoService;
+
+@RestController
+@RequestMapping("/api/programas-educativos")
+public class ProgramaEducativoController {
+    @Autowired
+    private ProgramaEducativoService programaEducativoService;
+
+    @GetMapping
+    public List<ProgramaEducativo> getAll() {
+        return programaEducativoService.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getById(@PathVariable Long id) {
+        Optional<ProgramaEducativo> programa = programaEducativoService.findById(id);
+        return programa.isPresent() ? ResponseEntity.ok(programa.get()) : ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/division/{divisionId}")
+    public ResponseEntity<?> create(@PathVariable Long divisionId, @RequestBody ProgramaEducativo programa) {
+        try {
+            ProgramaEducativo creado = programaEducativoService.saveWithDivision(divisionId, programa);
+            return ResponseEntity.ok(creado);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @RequestBody ProgramaEducativo programa) {
+        Optional<ProgramaEducativo> existing = programaEducativoService.findById(id);
+        if (existing.isPresent()) {
+            programa.setId(id);
+            return ResponseEntity.ok(programaEducativoService.save(programa));
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id) {
+        Optional<ProgramaEducativo> existing = programaEducativoService.findById(id);
+        if (existing.isPresent()) {
+            programaEducativoService.deleteById(id);
+            return ResponseEntity.ok().body("Programa educativo eliminado correctamente");
+        } else {
+            return ResponseEntity.status(404).body("Programa educativo no existe");
+        }
+    }
+}

--- a/src/main/java/mx/edu/uteq/idgs13/microservicio_division/repository/ProgramaEducativoRepository.java
+++ b/src/main/java/mx/edu/uteq/idgs13/microservicio_division/repository/ProgramaEducativoRepository.java
@@ -1,0 +1,7 @@
+package mx.edu.uteq.idgs13.microservicio_division.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import mx.edu.uteq.idgs13.microservicio_division.entity.ProgramaEducativo;
+
+public interface ProgramaEducativoRepository extends JpaRepository<ProgramaEducativo, Long> {
+}

--- a/src/main/java/mx/edu/uteq/idgs13/microservicio_division/service/DivisionService.java
+++ b/src/main/java/mx/edu/uteq/idgs13/microservicio_division/service/DivisionService.java
@@ -37,4 +37,27 @@ public class DivisionService {
         return resultado;
     }
 
+        public Division agregarProgramaEducativo(Long divisionId, ProgramaEducativo programa) {
+            Division division = divisionRepository.findById(divisionId).orElse(null);
+            if (division == null) {
+                throw new IllegalArgumentException("División no encontrada");
+            }
+            if (programa == null || programa.getPrograma() == null || programa.getPrograma().isEmpty()) {
+                throw new IllegalArgumentException("Programa educativo inválido");
+            }
+            division.getProgramasEducativos().add(programa);
+            return divisionRepository.save(division);
+        }
+
+        public Division borrarProgramaEducativo(Long divisionId, Long programaId) {
+            Division division = divisionRepository.findById(divisionId).orElse(null);
+            if (division == null) {
+                throw new IllegalArgumentException("División no encontrada");
+            }
+            boolean removed = division.getProgramasEducativos().removeIf(p -> p.getId().equals(programaId));
+            if (!removed) {
+                throw new IllegalArgumentException("Programa educativo no encontrado en la división");
+            }
+            return divisionRepository.save(division);
+        }
 }

--- a/src/main/java/mx/edu/uteq/idgs13/microservicio_division/service/DivisionService.java
+++ b/src/main/java/mx/edu/uteq/idgs13/microservicio_division/service/DivisionService.java
@@ -36,28 +36,4 @@ public class DivisionService {
         }
         return resultado;
     }
-
-        public Division agregarProgramaEducativo(Long divisionId, ProgramaEducativo programa) {
-            Division division = divisionRepository.findById(divisionId).orElse(null);
-            if (division == null) {
-                throw new IllegalArgumentException("División no encontrada");
-            }
-            if (programa == null || programa.getPrograma() == null || programa.getPrograma().isEmpty()) {
-                throw new IllegalArgumentException("Programa educativo inválido");
-            }
-            division.getProgramasEducativos().add(programa);
-            return divisionRepository.save(division);
-        }
-
-        public Division borrarProgramaEducativo(Long divisionId, Long programaId) {
-            Division division = divisionRepository.findById(divisionId).orElse(null);
-            if (division == null) {
-                throw new IllegalArgumentException("División no encontrada");
-            }
-            boolean removed = division.getProgramasEducativos().removeIf(p -> p.getId().equals(programaId));
-            if (!removed) {
-                throw new IllegalArgumentException("Programa educativo no encontrado en la división");
-            }
-            return divisionRepository.save(division);
-        }
 }

--- a/src/main/java/mx/edu/uteq/idgs13/microservicio_division/service/ProgramaEducativoService.java
+++ b/src/main/java/mx/edu/uteq/idgs13/microservicio_division/service/ProgramaEducativoService.java
@@ -1,0 +1,46 @@
+package mx.edu.uteq.idgs13.microservicio_division.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import mx.edu.uteq.idgs13.microservicio_division.entity.ProgramaEducativo;
+import mx.edu.uteq.idgs13.microservicio_division.repository.ProgramaEducativoRepository;
+
+@Service
+public class ProgramaEducativoService {
+    @Autowired
+    private mx.edu.uteq.idgs13.microservicio_division.repository.DivisionRepository divisionRepository;
+
+    public ProgramaEducativo saveWithDivision(Long divisionId, ProgramaEducativo programa) {
+        var divisionOpt = divisionRepository.findById(divisionId);
+        if (divisionOpt.isEmpty()) {
+            throw new IllegalArgumentException("División no encontrada");
+        }
+        var division = divisionOpt.get();
+        programa = programaEducativoRepository.save(programa);
+        division.getProgramasEducativos().add(programa);
+        divisionRepository.save(division);
+        return programa;
+    }
+    @Autowired
+    private ProgramaEducativoRepository programaEducativoRepository;
+
+    public List<ProgramaEducativo> findAll() {
+        return programaEducativoRepository.findAll();
+    }
+
+    public Optional<ProgramaEducativo> findById(Long id) {
+        return programaEducativoRepository.findById(id);
+    }
+
+    public ProgramaEducativo save(ProgramaEducativo programa) {
+        return programaEducativoRepository.save(programa);
+    }
+
+    public void deleteById(Long id) {
+        programaEducativoRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
Este Pull Request implementa la gestión de programas educativos en el microservicio de división.

Incluye:

-Endpoint POST para agregar un programa educativo vinculado a una división.
-Endpoint DELETE para eliminar un programa educativo, con validación y mensajes claros si el programa no existe.
-Refactorización: la lógica de programas educativos se movió a un servicio y controlador independiente.
-Pruebas manuales realizadas con Postman para ambos endpoints.

¿Cómo probar?

1.- Usar el endpoint POST /api/programa-educativo para agregar un programa, enviando el ID de la división.
2- Usar el endpoint DELETE /api/programa-educativo/{id} para eliminar un programa educativo.
3- Verificar que al intentar eliminar un programa inexistente, el endpoint responde con 404 y un mensaje claro.

Notas:

-Todos los cambios están en la rama feature-idgs13-agregar-programa-educativo.
-Listo para revisión y merge.